### PR TITLE
add option for legacy usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ENV PYTHONUNBUFFERED=1 \
     ISSUER_NAME=letsencrypt \
     ISSUER_KIND=ClusterIssuer \
     CERT_CLEANUP=false \
-    PATCH_SECRETNAME=true
+    PATCH_SECRETNAME=true \
+    ENABLE_LEGACY=false \
+    ENABLE_LEGACY_ONLY=false
 
 RUN pip install kubernetes
 COPY main.py /

--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ CERT_ISSUER_NAME = os.getenv("ISSUER_NAME", "letsencrypt")
 CERT_ISSUER_KIND = os.getenv("ISSUER_KIND", "ClusterIssuer")
 CERT_CLEANUP = os.getenv("CERT_CLEANUP", "false").lower() in ("yes", "true", "t", "1")
 PATCH_SECRETNAME = os.getenv("PATCH_SECRETNAME", "false").lower() in ("yes", "true", "t", "1")
+ENABLE_LEGACY = os.getenv("ENABLE_LEGACY", "false").lower() in ("yes", "true", "t", "1")
+ENABLE_LEGACY_ONLY = os.getenv("ENABLE_LEGACY_ONLY", "false").lower() in ("yes", "true", "t", "1")
 
 
 def safe_get(obj, keys, default=None):
@@ -147,19 +149,38 @@ def main():
     signal.signal(signal.SIGINT, exit_gracefully)
     signal.signal(signal.SIGTERM, exit_gracefully)
 
-    # deprecated traefik CRD
-    th1 = threading.Thread(target=watch_crd, args=("traefik.containo.us", "v1alpha1", "ingressroutes"), daemon=True)
-    th1.start()
+    if ENABLE_LEGACY_ONLY:
+        # deprecated traefik CRD
+        th1 = threading.Thread(target=watch_crd, args=("traefik.containo.us", "v1alpha1", "ingressroutes"), daemon=True)
+        th1.start()
 
-    # new traefik CRD    
-    th2 = threading.Thread(target=watch_crd, args=("traefik.io", "v1alpha1", "ingressroutes"), daemon=True)
-    th2.start()
+        # wait for threads to finish
+        while th1.is_alive():
+            th1.join(0.1)
+        logging.info(f"Legacy thread exited")
+    elif ENABLE_LEGACY:
+        # deprecated traefik CRD
+        th1 = threading.Thread(target=watch_crd, args=("traefik.containo.us", "v1alpha1", "ingressroutes"), daemon=True)
+        th1.start()
 
-    # wait for threads to finish
-    while th1.is_alive() and th2.is_alive():
-        th1.join(0.1)
-        th2.join(0.1)
-    logging.info(f"One of the threads exited {th1.is_alive()}, {th2.is_alive()}")
+        # new traefik CRD
+        th2 = threading.Thread(target=watch_crd, args=("traefik.io", "v1alpha1", "ingressroutes"), daemon=True)
+        th2.start()
+
+        # wait for threads to finish
+        while th1.is_alive() and th2.is_alive():
+            th1.join(0.1)
+            th2.join(0.1)
+        logging.info(f"One of the threads exited {th1.is_alive()}, {th2.is_alive()}")
+    else:
+        # new traefik CRD
+        th1 = threading.Thread(target=watch_crd, args=("traefik.io", "v1alpha1", "ingressroutes"), daemon=True)
+        th1.start()
+
+        # wait for threads to finish
+        while th1.is_alive():
+            th1.join(0.1)
+        logging.info(f"Thread exited") 
 
 
 if __name__ == '__main__':

--- a/traefik-certmanager.yaml
+++ b/traefik-certmanager.yaml
@@ -9,24 +9,24 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-certmanager
 rules:
-- apiGroups: ["traefik.containo.us"]
-  resources: ["ingressroutes"]
-  verbs: ["watch", "patch"]
-- apiGroups: ["traefik.io"]
-  resources: ["ingressroutes"]
-  verbs: ["watch", "patch"]
-- apiGroups: ["cert-manager.io"]
-  resources: ["certificates"]
-  verbs: ["get", "create", "delete"]
+  - apiGroups: ["traefik.containo.us"]
+    resources: ["ingressroutes"]
+    verbs: ["watch", "patch"]
+  - apiGroups: ["traefik.io"]
+    resources: ["ingressroutes"]
+    verbs: ["watch", "patch"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["get", "create", "delete"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-certmanager
 subjects:
-- kind: ServiceAccount
-  name: traefik-certmanager
-  namespace: traefik
+  - kind: ServiceAccount
+    name: traefik-certmanager
+    namespace: traefik
 roleRef:
   kind: ClusterRole
   name: traefik-certmanager
@@ -49,15 +49,19 @@ spec:
     spec:
       serviceAccount: traefik-certmanager
       containers:
-      - name: traefik-certmanager
-        image: kooper/traefik-certmanager
-        imagePullPolicy: Always
-        env:
-        - name: ISSUER_NAME
-          value: letsencrypt
-        - name: ISSUER_KIND
-          value: ClusterIssuer
-        - name: CERT_CLEANUP
-          value: "false"
-        - name: PATCH_SECRETNAME
-          value: "true"
+        - name: traefik-certmanager
+          image: kooper/traefik-certmanager
+          imagePullPolicy: Always
+          env:
+            - name: ISSUER_NAME
+              value: letsencrypt
+            - name: ISSUER_KIND
+              value: ClusterIssuer
+            - name: CERT_CLEANUP
+              value: "false"
+            - name: PATCH_SECRETNAME
+              value: "true"
+            - name: ENABLE_LEGACY
+              value: "false"
+            - name: ENABLE_LEGACY_ONLY
+              value: "false"


### PR DESCRIPTION
Enables env variables to manipulate monitoring old and new traefik api specs
